### PR TITLE
Fix for bug #4

### DIFF
--- a/generators/migration/Generator.php
+++ b/generators/migration/Generator.php
@@ -322,10 +322,11 @@ class Generator extends \yii\gii\Generator
                 unset($refs[0]);
 
                 $fks = implode(']], [[', array_keys($refs));
+                $fieldNames = implode('|', array_keys($refs));
                 $pks = implode(']], [[', array_values($refs));
 
                 $relation = "FOREIGN KEY ([[$fks]]) REFERENCES $refTableName ([[$pks]]) ON DELETE CASCADE ON UPDATE CASCADE";
-                $relations[$tableName][$refTable] = $relation;
+                $relations[$tableName][$fieldNames] = $relation;
             }
         }
         return $relations;


### PR DESCRIPTION
Use field name(s) on where foreign keys are generated to prevent overwriting earlier specified relations.
Fixes https://github.com/deesoft/yii2-gii/issues/4